### PR TITLE
feat: don't run on ci servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,24 +12,34 @@
 
 ## Usage
 
-To use `ado-npm-auth-lite` do this:
+You know that you need to create a user `.npmrc` file if you encounter the following message when you try to `npm i`:
+
+```sh
+npm error code E401
+npm error Unable to authenticate, your authentication token seems to be invalid.
+npm error To correct this please try logging in again with:
+npm error npm login
+```
+
+To get `ado-npm-auth-lite` to create the necessary user `.npmrc` file on your behalf, run the following command:
 
 ```shell
-az login
 npx --yes ado-npm-auth-lite --config .npmrc
 ```
+
+This requires that you are authenticated with Azure. To authenticate, run `az login`. [Follow these instructions to install the Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli). The `az login` command will prompt you to log in to Azure, so that a token may be acquired by `ado-npm-auth-lite`. It is not necessary to run `az login` if you are already authenticated with Azure.
 
 Typically `ado-npm-auth-lite` will be used as part of a `preinstall` script in your `package.json`:
 
 ```json
 "scripts": {
-  "preinstall": "az login && npx --yes ado-npm-auth-lite"
+  "preinstall": "npx --yes ado-npm-auth-lite"
 },
 ```
 
-This will ensure that the necessary authentication is set up before any `npm install` commands are run.
+`ado-npm-auth-lite` detects whether it is running in a CI environment and does not create a users `.npmrc` file in that situation. It uses the [ci-info](https://github.com/watson/ci-info) library to achieve this.
 
-The `az login` command will prompt you to log in to Azure, so that a token may be acquired. It is not necessary to run this command if you are already logged in. The `config` is optional, and if not supplied will default to the `.npmrc` in the project directory. Crucially, `ado-npm-auth-lite` requires the project `.npmrc` in order to operate.
+The `config` parameter is optional, and if not supplied will default to the `.npmrc` in the project directory. Crucially, `ado-npm-auth-lite` requires the project `.npmrc` file exists in order that it can acquire the information to run.
 
 ## Why Azure DevOps npm auth-lite?
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"@azure/identity": "^4.5.0",
 		"@clack/prompts": "^0.7.0",
 		"chalk": "^5.3.0",
+		"ci-info": "^4.0.0",
 		"zod": "^3.23.8",
 		"zod-validation-error": "^3.3.1"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       chalk:
         specifier: ^5.3.0
         version: 5.3.0
+      ci-info:
+        specifier: ^4.0.0
+        version: 4.0.0
       zod:
         specifier: ^3.23.8
         version: 3.23.8

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -29,17 +29,6 @@ export async function bin(args: string[]) {
 	const introPrompts = `${chalk.blueBright(`📦🔑 Welcome to`)} ${chalk.bgBlueBright.black(`ado-npm-auth-lite`)} ${chalk.blueBright(`${version}! 📦🔑`)}`;
 	const outroPrompts = `${chalk.blueBright(`📦🔑 Thanks for using`)} ${chalk.bgBlueBright.black(`ado-npm-auth-lite`)} ${chalk.blueBright(`${version}! 📦🔑`)}`;
 
-	if (ci.isCI) {
-		prompts.intro(introPrompts);
-		logLine();
-		logLine(
-			`Detected that you are running on a CI server (${ci.name ?? ""}) and so will not generate a user .npmrc file`,
-		);
-		prompts.outro(outroPrompts);
-
-		return StatusCodes.Success;
-	}
-
 	const { values } = parseArgs({
 		args,
 		options,
@@ -57,7 +46,6 @@ export async function bin(args: string[]) {
 	}
 
 	prompts.intro(introPrompts);
-
 	logLine();
 
 	const mappedOptions = {
@@ -84,6 +72,16 @@ export async function bin(args: string[]) {
 	}
 
 	const { config, email } = optionsParseResult.data;
+
+	// TODO: this will prevent this file from running tests on the server after this - create an override parameter
+	if (ci.isCI) {
+		logLine(
+			`Detected that you are running on a CI server (${ci.name ?? ""}) and so will not generate a user .npmrc file`,
+		);
+		prompts.outro(outroPrompts);
+
+		return StatusCodes.Success;
+	}
 
 	prompts.log.info(`options:
 - config: ${config ?? "[NONE SUPPLIED - WILL USE DEFAULT]"}

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -1,5 +1,6 @@
 import * as prompts from "@clack/prompts";
 import chalk from "chalk";
+import ci from "ci-info";
 import { parseArgs } from "node:util";
 import { fromZodError } from "zod-validation-error";
 
@@ -27,6 +28,17 @@ export async function bin(args: string[]) {
 
 	const introPrompts = `${chalk.blueBright(`📦🔑 Welcome to`)} ${chalk.bgBlueBright.black(`ado-npm-auth-lite`)} ${chalk.blueBright(`${version}! 📦🔑`)}`;
 	const outroPrompts = `${chalk.blueBright(`📦🔑 Thanks for using`)} ${chalk.bgBlueBright.black(`ado-npm-auth-lite`)} ${chalk.blueBright(`${version}! 📦🔑`)}`;
+
+	if (ci.isCI) {
+		prompts.intro(introPrompts);
+		logLine();
+		logLine(
+			`Detected that you are running on a CI server (${ci.name ?? ""}) and so will not generate a user .npmrc file`,
+		);
+		prompts.outro(outroPrompts);
+
+		return StatusCodes.Success;
+	}
 
 	const { values } = parseArgs({
 		args,


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to ado-npm-auth-lite! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #2 
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/johnnyreilly/ado-npm-auth-lite/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/johnnyreilly/ado-npm-auth-lite/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
It uses ci-info to detect and noops if it is on a CI server