### PR TITLE
fix: manually match version number to release version on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "azdo-npm-auth",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"description": "Set up local authentication to Azure DevOps npm feeds",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Attempt to get repo version number and npm version aligned.  See context here:

https://github.com/JoshuaKGoldberg/release-it-action/issues/672#issuecomment-3402756957